### PR TITLE
[🔨 Fix] figma의 스타일 가이드로 색상으로 semantic design token 수정

### DIFF
--- a/src/GlobalStyle.ts
+++ b/src/GlobalStyle.ts
@@ -9,7 +9,7 @@ const GlobalStyle = createGlobalStyle`
         -moz-osx-font-smoothing: grayscale;
 
         --color-text-dark: ${colors.semantic.text.dark};
-        --color-background-light: ${colors.semantic.background.light};
+        --color-background-light: ${colors.semantic.background.white};
         --font-size-paragraph: ${font.size.paragraph};
     }
 
@@ -17,7 +17,7 @@ const GlobalStyle = createGlobalStyle`
         font-size: 100%; /* 16px */
     };
 
-    body {
+    html > body {
         font-family: 'Noto Sans KR', sans-serif;
         line-height: 1.5;
         font-weight: 400;

--- a/src/styles/token/colors/index.ts
+++ b/src/styles/token/colors/index.ts
@@ -1,0 +1,4 @@
+import { scale } from './scale';
+import { semantic } from './semantic';
+
+export const colors = { scale, semantic };

--- a/src/styles/token/colors/rawValue.ts
+++ b/src/styles/token/colors/rawValue.ts
@@ -332,27 +332,3 @@ const raw = {
 };
 
 export { raw };
-export const {
-  slate,
-  gray,
-  zinc,
-  neutral,
-  stone,
-  red,
-  orange,
-  amber,
-  yellow,
-  lime,
-  green,
-  emerald,
-  teal,
-  cyan,
-  sky,
-  blue,
-  indigo,
-  violet,
-  purple,
-  fuchsia,
-  pink,
-  rose,
-} = raw;

--- a/src/styles/token/colors/scale.ts
+++ b/src/styles/token/colors/scale.ts
@@ -1,4 +1,4 @@
-import { raw } from './colorRawValue';
+import { raw } from './rawValue';
 
 const scale = {
   primary: {
@@ -109,42 +109,4 @@ const scale = {
   },
 };
 
-const semantic = {
-  primary: scale.primary.s600,
-  secondary: scale.secondary.s600,
-  success: scale.success.s600,
-  danger: scale.danger.s600,
-  warning: scale.warning.s600,
-  neutral: scale.neutral.s600, // 배경, 보조 텍스트, 구분선
-  neutralVariant: scale.neutralVariant.s600, // 보조적인 배경, 비활성 상태 UI
-  light: scale.neutral.s50,
-  dark: scale.neutral.s800,
-  info: scale.neutral.s600,
-  disabled: scale.neutralVariant.s600,
-  hover: {
-    primary: scale.primary.s400,
-    secondary: scale.secondary.s400,
-    neutral: scale.neutral.s400,
-    neutralVariant: scale.neutralVariant.s400,
-    success: scale.success.s400,
-    danger: scale.danger.s400,
-    warning: scale.warning.s400,
-    info: scale.info.s400,
-  },
-  background: {
-    light: scale.neutral.s0,
-    dark: scale.neutralVariant.s300,
-  },
-  text: {
-    light: scale.neutral.s50,
-    gray: scale.neutral.s600,
-    dark: scale.neutral.s900,
-    nav: scale.neutralVariant.s500,
-  },
-  border: {
-    light: scale.neutralVariant.s300,
-    focus: scale.primary.s500,
-  },
-};
-
-export const colors = { scale, semantic };
+export { scale };

--- a/src/styles/token/colors/semantic.ts
+++ b/src/styles/token/colors/semantic.ts
@@ -1,23 +1,23 @@
 import { scale } from './scale';
 
-const primaryValue = '#3E5371';
-const neutralValue = '#F6F9FC';
-const neutralVariantValue = '#CED4DA';
-const darkValue = '#081732';
-const grayLightValue = '#C2C6C9';
-const grayDarkValue = '#9CA3AF';
-const whiteValue = '#FFFFFF';
+const PRIMARY_COLOR = '#3E5371';
+const NEUTRAL_COLOR = '#F6F9FC';
+const NEUTRAL_VARIANT_COLOR = '#CED4DA';
+const DARK_COLOR = '#081732';
+const GRAY_LIGHT_COLOR = '#C2C6C9';
+const GRAY_DARK_COLOR = '#9CA3AF';
+const WHITE_COLOR = '#FFFFFF';
 
 const semantic = {
-  primary: primaryValue,
+  primary: PRIMARY_COLOR,
   secondary: '#A2C0DE',
   success: '#4CAF50',
   danger: '#DA626B',
   warning: scale.warning.s500,
-  neutral: neutralValue, // 배경, 보조 텍스트, 구분선
-  neutralVariant: neutralVariantValue, // 보조적인 배경, 비활성 상태 UI
-  info: grayDarkValue,
-  disabled: neutralVariantValue,
+  neutral: NEUTRAL_COLOR, // 주요 컨텐츠 배경, 보조 텍스트, 구분선
+  neutralVariant: NEUTRAL_VARIANT_COLOR, // 보조적인 배경, 비활성 상태 UI, 그림자 효과
+  info: GRAY_DARK_COLOR,
+  disabled: NEUTRAL_VARIANT_COLOR,
   hover: {
     primary: '#758AA7',
     secondary: '#C3D9EF',
@@ -26,23 +26,23 @@ const semantic = {
     warning: scale.warning.s400,
   },
   background: {
-    white: whiteValue,
-    light: neutralValue,
+    white: WHITE_COLOR,
+    light: NEUTRAL_COLOR,
     gray: '#F8F8F8',
-    dark: darkValue,
+    dark: DARK_COLOR,
   },
   text: {
-    white: whiteValue,
-    grayLight: grayLightValue,
-    grayDark: grayDarkValue,
-    dark: darkValue,
-    nav: primaryValue,
-    placeholder: grayLightValue,
-    disabled: grayDarkValue,
+    white: WHITE_COLOR,
+    grayLight: GRAY_LIGHT_COLOR,
+    grayDark: GRAY_DARK_COLOR,
+    dark: DARK_COLOR,
+    nav: PRIMARY_COLOR,
+    placeholder: GRAY_LIGHT_COLOR,
+    disabled: GRAY_DARK_COLOR,
   },
   border: {
-    light: neutralValue,
-    focus: primaryValue,
+    light: NEUTRAL_COLOR,
+    focus: PRIMARY_COLOR,
   },
 };
 

--- a/src/styles/token/colors/semantic.ts
+++ b/src/styles/token/colors/semantic.ts
@@ -1,0 +1,49 @@
+import { scale } from './scale';
+
+const primaryValue = '#3E5371';
+const neutralValue = '#F6F9FC';
+const neutralVariantValue = '#CED4DA';
+const darkValue = '#081732';
+const grayLightValue = '#C2C6C9';
+const grayDarkValue = '#9CA3AF';
+const whiteValue = '#FFFFFF';
+
+const semantic = {
+  primary: primaryValue,
+  secondary: '#A2C0DE',
+  success: '#4CAF50',
+  danger: '#DA626B',
+  warning: scale.warning.s500,
+  neutral: neutralValue, // 배경, 보조 텍스트, 구분선
+  neutralVariant: neutralVariantValue, // 보조적인 배경, 비활성 상태 UI
+  info: grayDarkValue,
+  disabled: neutralVariantValue,
+  hover: {
+    primary: '#758AA7',
+    secondary: '#C3D9EF',
+    success: '#91CC93',
+    danger: '#EB949B',
+    warning: scale.warning.s400,
+  },
+  background: {
+    white: whiteValue,
+    light: neutralValue,
+    gray: '#F8F8F8',
+    dark: darkValue,
+  },
+  text: {
+    white: whiteValue,
+    grayLight: grayLightValue,
+    grayDark: grayDarkValue,
+    dark: darkValue,
+    nav: primaryValue,
+    placeholder: grayLightValue,
+    disabled: grayDarkValue,
+  },
+  border: {
+    light: neutralValue,
+    focus: primaryValue,
+  },
+};
+
+export { semantic };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**디자인 토큰 색상 값을 피그마 스타일 가이드에 맞춰서 수정**

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

현재 설정된 디자인 토큰 색상 기준은 [당근 디자인토큰 시스템](https://github.com/daangn/seed-design/tree/main/packages/design-token)과 [tailwind css의 색상 팔레트](https://tailwindcss.com/docs/customizing-colors)를 기준으로 raw 값과 sclae 값, semantic 값이 정의 되어 있습니다.

[피그마에 설정된 스타일 가이드](https://www.figma.com/design/WY2HeYvqvZsi4nhfcK6IrL/V.M.?node-id=86-5812&t=iA97ExpVz5lw0vSU-4) 기준으로 semantic 색상 값을 수정하는 작업을 합니다.

## 🔧 변경 사항

**디자인 토큰 색상 semantic 값**
- styles/token/colors.ts 에서 관리하는 scale token과 semantic token을 분리
- semantic token을 스타일가이드의 색상 값으로 수정 (정의되지 않은 일부 색상은 기존 scale token 값 연결)
- GlobalStyle 컴포넌트의 정의된 전역 body 배경색 수정 (colors.semantic.background.light ➡️ colors.semantic.background.white)


## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
