### PR TITLE
[Fix] globalStyle과 디자인 토큰 값을 rem 단위로 변경

### DIFF
--- a/src/GlobalStyle.ts
+++ b/src/GlobalStyle.ts
@@ -14,7 +14,7 @@ const GlobalStyle = createGlobalStyle`
     }
 
     html {
-        font-size: 100%; /* 16px */
+        font-size: 62.5%; /* 10px */
     };
 
     html > body {
@@ -30,7 +30,7 @@ const GlobalStyle = createGlobalStyle`
         /** 데스크탑 이하 디바이스 **/
 
         html {
-            font-size: 90%;
+            font-size: 56.25%;
         }
     }
 

--- a/src/styles/token/font.ts
+++ b/src/styles/token/font.ts
@@ -1,11 +1,11 @@
 export const font = {
   size: {
-    heading: '32px',
-    headingLight: '28px',
-    subHeading: '24px',
-    paragraph: '16px',
-    info: '14px',
-    min: '13px',
+    heading: '3.2rem',
+    headingLight: '2.8rem',
+    subHeading: '2.4rem',
+    paragraph: '1.6rem',
+    info: '1.4rem',
+    min: '1.3rem',
     values: {
       heading: 36,
       subHeading: 24,

--- a/src/styles/token/height.ts
+++ b/src/styles/token/height.ts
@@ -1,7 +1,7 @@
 const height = {
   mobile: {
-    header: '48px',
-    nav: '48px',
+    header: '4.8rem',
+    nav: '4.8rem',
   },
 };
 

--- a/src/styles/token/padding.ts
+++ b/src/styles/token/padding.ts
@@ -1,10 +1,10 @@
 export const padding = {
-  xs: '4px',
-  sm: '8px',
-  md: '16px',
-  lg: '36px',
-  xl: '48px',
-  xxl: '60px',
+  xs: '0.4rem',
+  sm: '0.8rem',
+  md: '1.6rem',
+  lg: '3.6rem',
+  xl: '4.8rem',
+  xxl: '6rem',
   values: {
     xs: 4,
     sm: 8,


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[globalStyle과 디자인 토큰 값을 rem 단위로 변경 #22 ]**

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

- globalStyle과 디자인 토큰 값을 rem 단위로 변경
- html 기준 font-size 를 62.5%로 변경
- 디자인 토큰의 px로 정의되어 있던 값들을 필요에 따라 rem 단위로 변경

## 🔧 변경 사항

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
