### PR TITLE
[🐞 BugFix] 더 이상 지원하지 않는 stylelint-config-styled-components 라이브러리 제거

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,8 +1,5 @@
 {
-  "extends": [
-    "stylelint-config-standard",
-    "stylelint-config-styled-components"
-  ],
+  "extends": ["stylelint-config-standard"],
   "customSyntax": "@stylelint/postcss-css-in-js",
   "rules": {}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "prettier": "^3.4.2",
         "stylelint": "^16.12.0",
         "stylelint-config-standard": "^36.0.1",
-        "stylelint-config-styled-components": "^0.1.1",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.18.2",
         "vite": "^6.0.5",
@@ -5799,12 +5798,6 @@
       "peerDependencies": {
         "stylelint": "^16.1.0"
       }
-    },
-    "node_modules/stylelint-config-styled-components": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/stylelint-config-styled-components/-/stylelint-config-styled-components-0.1.1.tgz",
-      "integrity": "sha512-z5Xz/9GmvxO6e/DLzBMwkB85zHxEEjN6K7Cj80Bi+o/9vR9eS3GX3E9VuMnX9WLFYulqbqLtTapGGY28JBiy9Q==",
-      "dev": true
     },
     "node_modules/stylelint/node_modules/ansi-regex": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "prettier": "^3.4.2",
     "stylelint": "^16.12.0",
     "stylelint-config-standard": "^36.0.1",
-    "stylelint-config-styled-components": "^0.1.1",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.18.2",
     "vite": "^6.0.5",


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**더 이상 지원하지 않는 stylelint-config-styled-components 라이브러리 제거**

## 📋 작업 내용

잘못된 린트 에러를 발생시키는 버그를 확인하였으며 자세한 내용은 이슈에 정리했습니다. #38 

- 스타일린트 설정에서 stylelint-config-styled-components 제거

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.

- [x]  stylelint-config-styled-components 라이브러리 삭제

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
