### PR TITLE
[FEAT] 프로필 페이지에 사용자 정보 렌더링을 위한 컴포넌트 구현

### DIFF
--- a/src/components/card/ProfileCard/ProfileCard.styles.ts
+++ b/src/components/card/ProfileCard/ProfileCard.styles.ts
@@ -1,0 +1,53 @@
+import { font, padding } from '@/styles';
+import styled from 'styled-components';
+
+export const CardContainer = styled.div`
+  width: 100%;
+  max-width: 76rem;
+  padding: 0 ${padding['md']};
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  gap: ${padding['md']};
+  transition: 0.3s;
+
+  @media (width <= 768px) {
+    padding-top: ${padding.xl};
+  }
+`;
+
+export const CardImage = styled.img`
+  width: 10rem;
+  height: 10rem;
+`;
+
+export const CardWrapper = styled.div`
+  flex: 1 0 auto;
+`;
+
+export const CardTitle = styled.h3`
+  font-size: ${font.size['heading']};
+  font-weight: ${font.weight['heading']};
+  margin-bottom: 1.6rem;
+`;
+
+export const CardInfoBox = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const CardStack = styled.button`
+  cursor: pointer;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const B = styled.b`
+  font-weight: ${font.weight['heading']};
+`;

--- a/src/components/card/ProfileCard/ProfileCard.tsx
+++ b/src/components/card/ProfileCard/ProfileCard.tsx
@@ -1,0 +1,34 @@
+import * as S from './ProfileCard.styles';
+
+/**
+ * 프로필 페이지의 사용자 정보 렌더링을 위한 카드 컴포넌트
+ * @returns
+ */
+const ProfileCard = () => {
+  return (
+    <S.CardContainer>
+      <S.CardImage src="src/assets/avatar.svg" />
+      <S.CardTitle>이민태</S.CardTitle>
+      <S.CardInfoBox>
+        <S.CardStack>
+          <S.B>1천</S.B>
+          <span>플리</span>
+        </S.CardStack>
+        <S.CardStack>
+          <S.B>100</S.B>
+          <span>팔로워</span>
+        </S.CardStack>
+        <S.CardStack>
+          <S.B>1만</S.B>
+          <span>팔로잉</span>
+        </S.CardStack>
+      </S.CardInfoBox>
+      <p>
+        askdjas sakljdaslkd jaskl jaosi djqwio jqiw jdmaosik mqw nifo
+        qfasiojdqiwojmsoi jasoi jda siojdqwiop jqwp idjq iojq odddd
+      </p>
+    </S.CardContainer>
+  );
+};
+
+export default ProfileCard;

--- a/src/components/card/ProfileCard/index.ts
+++ b/src/components/card/ProfileCard/index.ts
@@ -1,0 +1,1 @@
+export { default as ProfileCard } from './ProfileCard';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**프로필 페이지에 사용자 정보 렌더링을 위한 컴포넌트 구현 #21 **

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

- 프로필 페이지에 사용자 정보 렌더링을 위한 컴포넌트 구현
- 마크업 단계 까지만 구현

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
