### PR TITLE
[FEAT] 검색 페이지에서 무한 로딩에 사용될 사용자 카드 컴포넌트 마크업

### DIFF
--- a/src/components/card/UserCard/UserCard.styles.ts
+++ b/src/components/card/UserCard/UserCard.styles.ts
@@ -1,0 +1,46 @@
+import { font, padding } from '@/styles';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+export const CardContainer = styled(Link)`
+  width: 100%;
+  max-width: 48.5rem;
+  padding: 0 ${padding['md']};
+  display: flex;
+  align-items: center;
+  gap: ${padding['md']};
+  transition: 0.3s;
+  cursor: pointer;
+`;
+
+export const CardImage = styled.img`
+  width: 7rem;
+  height: 7rem;
+`;
+
+export const CardWrapper = styled.div`
+  flex: 1 0 auto;
+`;
+
+export const CardTitle = styled.h3`
+  font-weight: ${font.weight['heading']};
+  margin-bottom: 1.6rem;
+`;
+
+export const CardInfoBox = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const CardStack = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const B = styled.b`
+  font-weight: ${font.weight['heading']};
+`;

--- a/src/components/card/UserCard/UserCard.tsx
+++ b/src/components/card/UserCard/UserCard.tsx
@@ -1,0 +1,31 @@
+import * as S from './UserCard.styles';
+/**
+ * 검색 페이지의 사용자 목록 렌더링을 위한 카드 컴포넌트
+ * @returns
+ */
+const UserCard = () => {
+  return (
+    <S.CardContainer to={{}}>
+      <S.CardImage src="src/assets/avatar.svg" />
+      <S.CardWrapper>
+        <S.CardTitle>이민태</S.CardTitle>
+        <S.CardInfoBox>
+          <S.CardStack>
+            <S.B>1천</S.B>
+            <span>플리</span>
+          </S.CardStack>
+          <S.CardStack>
+            <S.B>100</S.B>
+            <span>팔로워</span>
+          </S.CardStack>
+          <S.CardStack>
+            <S.B>1만</S.B>
+            <span>팔로잉</span>
+          </S.CardStack>
+        </S.CardInfoBox>
+      </S.CardWrapper>
+    </S.CardContainer>
+  );
+};
+
+export default UserCard;

--- a/src/components/card/UserCard/index.ts
+++ b/src/components/card/UserCard/index.ts
@@ -1,0 +1,1 @@
+export { default as UserCard } from './UserCard';

--- a/src/components/card/index.ts
+++ b/src/components/card/index.ts
@@ -1,0 +1,3 @@
+export { UserCard } from './UserCard';
+export { ProfileCard } from './ProfileCard';
+export { ExplorePlayListCard } from './ExplorePlayListCard';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from './core';
 export * from './layout';
 export { GoogleLoginButton } from './GoogleLoginButton';
+export { UserCard, ProfileCard, ExplorePlayListCard } from './card';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**검색 페이지에서 무한 로딩에 사용될 사용자 카드 컴포넌트 마크업 #45 **

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

- 검색 페이지에서 무한 로딩에 사용될 사용자 카드 컴포넌트 마크업

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.

- [ ] 검색 페이지에서 무한 로딩에 사용될 사용자 카드 컴포넌트 마크업
- [ ] components 폴더의 index에 card 컴포넌트들 re-export 코드 추가

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
