### PR TITLE
[✨ Feature] 공통 태그 컴포넌트 구현

### DIFF
--- a/src/components/card/ExplorePlayListCard/ExplorePlayListCard.styles.ts
+++ b/src/components/card/ExplorePlayListCard/ExplorePlayListCard.styles.ts
@@ -1,5 +1,5 @@
-import { colors, font, padding } from '@/styles';
 import styled from 'styled-components';
+import { font, padding } from '@/styles';
 
 export const CardContainer = styled.div`
   width: 100%;
@@ -32,11 +32,6 @@ export const CardInfoBox = styled.div`
   justify-content: space-between;
   align-items: flex-start;
   gap: ${padding.sm};
-`;
-
-export const CardTagBox = styled.div`
-  font-size: ${font.size.info};
-  color: ${colors.semantic.text.nav};
 `;
 
 export const CardInfoLine = styled.div`

--- a/src/components/card/ExplorePlayListCard/ExplorePlayListCard.tsx
+++ b/src/components/card/ExplorePlayListCard/ExplorePlayListCard.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@/components';
+import { Button, TagList } from '@/components';
 import { RiMore2Fill } from 'react-icons/ri';
 import * as S from './ExplorePlayListCard.styles';
 
@@ -10,11 +10,9 @@ const ExplorePlayListCard = () => {
       </S.CardImageBox>
       <S.CardInfoBox>
         <h3>고양이는 너무 귀여웡</h3>
-        <S.CardTagBox>
-          <span>#고양</span>
-          <span>#고영</span>
-          <span>#냐옹이</span>
-        </S.CardTagBox>
+        <div>
+          <TagList tags={['고양', '고영', '냐옹이']} tagType="text" />
+        </div>
         <S.CardInfoLine>
           <span>댓글 1천· 좋아요 1만</span>
           <Button $bgColor="white" $size="xs">

--- a/src/components/core/RoundTag/RoundTag.styles.ts
+++ b/src/components/core/RoundTag/RoundTag.styles.ts
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+import { border, colors, font, padding } from '@/styles';
+
+export const RoundTag = styled.span`
+  background-color: ${colors.semantic.secondary};
+  color: white;
+  padding: ${padding.xs} 0.6rem ${padding.xs} ${padding.sm};
+  border-radius: ${border.radius.lg};
+  font-size: 1.2rem;
+  font-weight: ${font.weight.subHeading};
+  display: inline-flex;
+  align-items: center;
+
+  button {
+    line-height: 0;
+    background: none;
+    border: none;
+    margin-left: ${padding.xs};
+    padding: 0.2rem;
+    color: ${colors.semantic.text.white};
+    cursor: pointer;
+  }
+
+  &:hover {
+    background-color: ${colors.semantic.hover.secondary};
+  }
+`;

--- a/src/components/core/RoundTag/RoundTag.tsx
+++ b/src/components/core/RoundTag/RoundTag.tsx
@@ -1,0 +1,22 @@
+import { RiCloseLine } from 'react-icons/ri';
+import * as S from './RoundTag.styles';
+
+interface IRoundTag {
+  text: string;
+  isEditable?: boolean;
+}
+
+const RoundTag = ({ text, isEditable = false }: IRoundTag) => {
+  return (
+    <S.RoundTag>
+      #{text}
+      {isEditable && (
+        <button type="button">
+          <RiCloseLine size="1.2rem" />
+        </button>
+      )}
+    </S.RoundTag>
+  );
+};
+
+export default RoundTag;

--- a/src/components/core/RoundTag/index.ts
+++ b/src/components/core/RoundTag/index.ts
@@ -1,0 +1,1 @@
+export { default as RoundTag } from './RoundTag';

--- a/src/components/core/TagList/index.ts
+++ b/src/components/core/TagList/index.ts
@@ -1,0 +1,1 @@
+export { default as TagList } from './TagList';

--- a/src/components/core/TextTag/TextTag.styles.ts
+++ b/src/components/core/TextTag/TextTag.styles.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+import { colors, font } from '@/styles';
+
+export const TextTag = styled.span`
+  font-size: ${font.size.info};
+  color: ${colors.semantic.text.nav};
+`;

--- a/src/components/core/TextTag/TextTag.tsx
+++ b/src/components/core/TextTag/TextTag.tsx
@@ -1,0 +1,7 @@
+import * as S from './TextTag.styles';
+
+const TextTag = ({ text }: { text: string }) => {
+  return <S.TextTag>#{text}</S.TextTag>;
+};
+
+export default TextTag;

--- a/src/components/core/TextTag/index.ts
+++ b/src/components/core/TextTag/index.ts
@@ -1,0 +1,1 @@
+export { default as TextTag } from './TextTag';

--- a/src/components/core/index.ts
+++ b/src/components/core/index.ts
@@ -6,3 +6,6 @@ export { PageTitle } from './PageTitle';
 export { Input } from './Input';
 export { Textarea } from './Textarea';
 export { Switch } from './Switch';
+export { RoundTag } from './RoundTag';
+export { TextTag } from './TextTag';
+export { TagList } from './TagList';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간략히 적어주세요]**

## 📋 작업 내용

- 라운드형 태그, 텍스트형 태그로 나눠서 각각 구현
- 태그List 컴포넌트에 라운드형, 텍스트형 모아서 구현

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.

- [x] 각 태그 컴포넌트 구현
- [x] 태그List 컴포넌트 구현
- [ ] 태그 컨테이너 너비 변동에 따른 숨김 및 숨긴 개수 표시

## 📄 기타

태그 컨테이너 너비 변동에 따른 숨김 및 숨긴 개수 표시는 시도해보았는데,
부모 요소가 추가되는 Tag의 길이에 따라 TagList의 너비가 고정되지 않고 동적으로 변해서
부모 너비에 따라 숨긴 태그 처리에 문제가 있어 미뤄놓았습니다.

부모 컴포넌트에서 윈도우 resize에 따른 현재 너비 상태를 관리하고,
TagList에도 prop으로 부모너비를 전달해서 구현하면 가능은 할 것 같으나 좋은 방법인지 모르겠네요.
