### PR TITLE
[✨ Feature] 파이어스토어 DB의 playlist API 함수와 tanstack-query를 적용한 커스텀 훅 생성

### DIFF
--- a/src/api/service/index.ts
+++ b/src/api/service/index.ts
@@ -1,1 +1,2 @@
 export * from './user';
+export * from './playlist';

--- a/src/api/service/playlist/index.ts
+++ b/src/api/service/playlist/index.ts
@@ -1,0 +1,1 @@
+export * from './playlistService';

--- a/src/api/service/playlist/playlistService.ts
+++ b/src/api/service/playlist/playlistService.ts
@@ -1,0 +1,54 @@
+import {
+  addDocument,
+  getDocument,
+  updateDocument,
+  deleteDocument,
+} from '@/utils';
+import { DB_COLLECTION } from '@/constant';
+import type { IPlaylistAPISchema } from '@/types';
+
+/**
+ * Firestore에서 플레이리스트 정보 조회
+ * @param {string} playlistSn - 플레이리스트 고유 ID
+ * @returns {Promise<IPlaylistAPISchema | null>} - 플레이리스트 데이터 또는 null
+ */
+const getPlaylist = async (
+  playlistSn: string,
+): Promise<IPlaylistAPISchema | null> =>
+  getDocument<IPlaylistAPISchema>(DB_COLLECTION.PLAYLIST, playlistSn);
+
+/**
+ * Firestore에 신규 플레이리스트 등록
+ * @param {IPlaylistAPISchema} playlistData - 플레이리스트 정보
+ * @returns {Promise<void>}
+ */
+const addPlaylist = async (playlistData: IPlaylistAPISchema): Promise<void> =>
+  addDocument(DB_COLLECTION.PLAYLIST, playlistData.playlistSn, playlistData);
+
+/**
+ * Firestore에 플레이리스트 정보 업데이트
+ * @param {string} playlistSn - 플레이리스트 시리얼 넘버
+ * @param {Partial<IPlaylistAPISchema>} updates - 수정할 플레이리스트 정보
+ * @returns {Promise<void>}
+ */
+const updatePlaylist = async (
+  playlistSn: string,
+  updates: Partial<IPlaylistAPISchema>,
+): Promise<void> =>
+  updateDocument<IPlaylistAPISchema>(
+    DB_COLLECTION.PLAYLIST,
+    playlistSn,
+    updates,
+  );
+
+/**
+ * Firestore에서 플레이리스트 삭제
+ * @param {string} playlistSn - 플레이리스트 고유 ID
+ * @returns {Promise<void>}
+ */
+const deletePlaylist = async (playlistSn: string): Promise<void> => {
+  if (!playlistSn) throw new Error('Invalid playlist ID');
+  await deleteDocument(DB_COLLECTION.PLAYLIST, playlistSn);
+};
+
+export { getPlaylist, addPlaylist, updatePlaylist, deletePlaylist };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,3 +2,4 @@ export { default as useAuth } from './useAuth';
 export { default as useVisibilityToggle } from './useVisibilityToggle';
 export { default as useFetchUserInfo } from './useFetchUserInfo';
 export { default as useInterestSelection } from './useInterestSelection';
+export * from './playlist';

--- a/src/hooks/playlist/index.ts
+++ b/src/hooks/playlist/index.ts
@@ -1,0 +1,4 @@
+export { default as usePostPlaylist } from './usePostPlaylist';
+export { default as useFetchPlaylist } from './useFetchPlaylist';
+export { default as useUpdatePlaylist } from './useUpdatePlaylist';
+export { default as useDeletePlaylist } from './useDeletePlaylist';

--- a/src/hooks/playlist/useDeletePlaylist.ts
+++ b/src/hooks/playlist/useDeletePlaylist.ts
@@ -1,0 +1,19 @@
+import { useMutation } from '@tanstack/react-query';
+import { deletePlaylist } from '@/api';
+
+const useDeletePlaylist = () => {
+  return useMutation<void, Error, string>({
+    mutationFn: async (playlistSn: string) => {
+      if (!playlistSn) throw new Error('Invalid playlist ID');
+      await deletePlaylist(playlistSn);
+    },
+    onSuccess: () => {
+      console.log('플레이리스트 삭제 성공!');
+    },
+    onError: (error: Error) => {
+      console.error('플레이리스트 삭제 실패:', error.message);
+    },
+  });
+};
+
+export default useDeletePlaylist;

--- a/src/hooks/playlist/useFetchPlaylist.ts
+++ b/src/hooks/playlist/useFetchPlaylist.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { getPlaylist } from '@/api';
+import type { IPlaylistAPISchema } from '@/types';
+
+const useFetchPlaylist = (playlistSn: string) => {
+  /**
+   * @param {string} playlistSn - 플레이리스트 고유 ID
+   */
+  return useQuery<IPlaylistAPISchema | null, Error>({
+    queryKey: ['playlist', playlistSn],
+    queryFn: async () => {
+      if (!playlistSn) throw new Error('Invalid playlist ID');
+      return await getPlaylist(playlistSn);
+    },
+    enabled: !!playlistSn, // playlistSn이 있을 때만 실행
+    staleTime: 1000 * 60 * 5, // 5분 동안 데이터를 신선하게 유지
+    refetchOnWindowFocus: false, // 포커스 시 다시 가져오기 방지
+  });
+};
+
+export default useFetchPlaylist;

--- a/src/hooks/playlist/usePostPlaylist.ts
+++ b/src/hooks/playlist/usePostPlaylist.ts
@@ -1,0 +1,20 @@
+import { useMutation } from '@tanstack/react-query';
+import { addPlaylist } from '@/api';
+import type { IPlaylistAPISchema } from '@/types';
+
+const usePostPlaylist = () => {
+  return useMutation<void, Error, IPlaylistAPISchema>({
+    mutationFn: async (playlistData: IPlaylistAPISchema) => {
+      if (!playlistData) throw new Error('Invalid playlist data');
+      await addPlaylist(playlistData);
+    },
+    onSuccess: () => {
+      console.log('플레이리스트 추가 성공!');
+    },
+    onError: (error: Error) => {
+      console.error('플레이리스트 추가 실패:', error.message);
+    },
+  });
+};
+
+export default usePostPlaylist;

--- a/src/hooks/playlist/useUpdatePlaylist.ts
+++ b/src/hooks/playlist/useUpdatePlaylist.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query';
+import { updatePlaylist } from '@/api';
+import type { IPlaylistAPISchema } from '@/types';
+
+const useUpdatePlaylist = () => {
+  return useMutation<
+    void,
+    Error,
+    { playlistSn: string; updates: Partial<IPlaylistAPISchema> }
+  >({
+    mutationFn: async ({ playlistSn, updates }) => {
+      if (!playlistSn || !updates) throw new Error('Invalid update data');
+      await updatePlaylist(playlistSn, updates);
+    },
+    onSuccess: () => {
+      console.log('플레이리스트 업데이트 성공!');
+    },
+    onError: (error: Error) => {
+      console.error('플레이리스트 업데이트 실패:', error.message);
+    },
+  });
+};
+
+export default useUpdatePlaylist;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './userTypes';
+export * from './playlistTypes';

--- a/src/types/playlistTypes.ts
+++ b/src/types/playlistTypes.ts
@@ -1,0 +1,13 @@
+export interface IPlaylistAPISchema {
+  playlistSn: string;
+  userSn: string;
+  title: string;
+  content: string;
+  likes: string[];
+  comments: string[];
+  date: string;
+  disclosure: boolean;
+  hashTags: string[];
+  thumbnailUrl: string;
+  links: string[];
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**playlist 도메인에 관련된 파이어스토어 api 관련 로직**

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

- 파이어스토어 DB의 playlist API 함수 생성
- playlist의 tanstack-query를 적용한 커스텀 훅 생성

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.

- playlistType.ts 추가 : playlist api 스키마 정의
- api/service/playlist 추가 :  playlist API 함수 생성
- hooks/playlist 추가 : playlist API 서버상태 관리 및 비동기 처리를 위한 커스텀훅 생성

## 📸 스크린샷 (선택 사항)

- api/service 디렉토리 구조

  ![image](https://github.com/user-attachments/assets/885013e6-07c6-4c45-955c-b4c7766e4ebc)


- hook/playlist 디렉토리 구조

  ![image](https://github.com/user-attachments/assets/b4a7d6d5-5755-4450-8a03-e619c73f0df2)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
