### PR TITLE
[✨ Feature] 파이어스토어 콜랙션 DB의 전체 Document 호출하는 유틸함수와 useFetchAllPlaylist 커스텀 훅 추가

### DIFF
--- a/src/api/service/playlist/playlistService.ts
+++ b/src/api/service/playlist/playlistService.ts
@@ -1,11 +1,19 @@
 import {
   addDocument,
   getDocument,
+  getAllDocument,
   updateDocument,
   deleteDocument,
 } from '@/utils';
 import { DB_COLLECTION } from '@/constant';
 import type { IPlaylistAPISchema } from '@/types';
+
+/**
+ * Firestore에서 플레이리스트 정보 조회
+ * @returns {Promise<IPlaylistAPISchema[] | null>} - 플레이리스트 데이터 또는 null
+ */
+const getAllPlaylist = async (): Promise<IPlaylistAPISchema[] | null> =>
+  getAllDocument<IPlaylistAPISchema>(DB_COLLECTION.PLAYLIST);
 
 /**
  * Firestore에서 플레이리스트 정보 조회
@@ -51,4 +59,10 @@ const deletePlaylist = async (playlistSn: string): Promise<void> => {
   await deleteDocument(DB_COLLECTION.PLAYLIST, playlistSn);
 };
 
-export { getPlaylist, addPlaylist, updatePlaylist, deletePlaylist };
+export {
+  getAllPlaylist,
+  getPlaylist,
+  addPlaylist,
+  updatePlaylist,
+  deletePlaylist,
+};

--- a/src/hooks/playlist/index.ts
+++ b/src/hooks/playlist/index.ts
@@ -1,4 +1,5 @@
 export { default as usePostPlaylist } from './usePostPlaylist';
 export { default as useFetchPlaylist } from './useFetchPlaylist';
+export { default as useFetchAllPlaylist } from './useFetchAllPlaylist';
 export { default as useUpdatePlaylist } from './useUpdatePlaylist';
 export { default as useDeletePlaylist } from './useDeletePlaylist';

--- a/src/hooks/playlist/useFetchAllPlaylist.ts
+++ b/src/hooks/playlist/useFetchAllPlaylist.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import { getAllPlaylist } from '@/api';
+import type { IPlaylistAPISchema } from '@/types';
+
+const useFetchAllPlaylist = () => {
+  return useQuery<IPlaylistAPISchema[] | null, Error>({
+    queryKey: ['playlists'],
+    queryFn: async () => await getAllPlaylist(),
+    staleTime: 1000 * 60 * 5,
+    refetchOnWindowFocus: false,
+  });
+};
+
+export default useFetchAllPlaylist;

--- a/src/utils/dbUtil.ts
+++ b/src/utils/dbUtil.ts
@@ -1,5 +1,7 @@
 import { DB } from '@/api';
 import {
+  collection,
+  getDocs,
   doc,
   getDoc,
   setDoc,
@@ -10,18 +12,42 @@ import {
 } from 'firebase/firestore/lite';
 
 /**
+ * Firestore에서 전체 문서 조회
+ * @param collection - 컬렉션 이름
+ */
+export const getAllDocument = async <T>(
+  collectionName: string,
+): Promise<T[] | null> => {
+  try {
+    const colRef = collection(DB, collectionName);
+    const colSnap = await getDocs(colRef);
+
+    if (colSnap.empty) {
+      return []; // 문서가 없을 경우 빈 배열 반환
+    }
+
+    // 문서 데이터를 배열로 변환 (중첩 배열 방지)
+    const documents: T[] = colSnap.docs.map((doc) => doc.data() as T);
+    return documents;
+  } catch (error) {
+    console.error('전체 문서 조회 실패:', error);
+    return null;
+  }
+};
+
+/**
  * Firestore에서 문서 조회
  * @param collection - 컬렉션 이름
  * @param docId - 문서 ID
  * @param parser - 데이터 파싱 함수 (선택사항)
  */
 export const getDocument = async <T>(
-  collection: string,
+  collectionName: string,
   docId: string,
   parser?: (data: DocumentData) => T,
 ): Promise<T | null> => {
   try {
-    const docRef = doc(DB, collection, docId);
+    const docRef = doc(DB, collectionName, docId);
     const docSnap = await getDoc(docRef);
 
     if (!docSnap.exists()) {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간략히 적어주세요]**

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

- 파이어스토어의 콜렉션 별 전체 문서 리스트를 조회하는 유틸함수 추가
- 전체 playlist 를 조회하는 커스텀 훅 추가

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.

- [x] 파이어스토어 getAllDocument 유틸함수 추가
- [x] playlist 콜렉션의 전체 문서를 호출하는 getAllPlaylist api 함수 추가
- [x] getAllPlaylist 힘수의 서버상태 관리와 비동기 처리를 위한 useFetchAllPlaylist 커스텀 훅 생성

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
