### PR TITLE
[🎨 Design] 각 페이지별 기능 구현 후 UI 틀어지는 부분 수정

### DIFF
--- a/src/components/card/ExplorePlayListCard/ExplorePlayListCard.styles.ts
+++ b/src/components/card/ExplorePlayListCard/ExplorePlayListCard.styles.ts
@@ -4,11 +4,10 @@ import { font, padding } from '@/styles';
 export const CardContainer = styled.div`
   width: 100%;
   max-width: 48.5rem;
-  padding: 0 ${padding['md']};
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: ${padding['md']};
+  gap: ${padding.md};
   transition: 0.3s;
   cursor: pointer;
 `;

--- a/src/components/layout/mobile/MobileSearch/MobileSearch.styles.ts
+++ b/src/components/layout/mobile/MobileSearch/MobileSearch.styles.ts
@@ -5,12 +5,12 @@ export const MobileSearch = styled.article`
   z-index: 1;
   position: absolute;
   top: ${height.mobile.header};
-  right: ${padding.md};
+  right: 0;
   width: 100%;
   padding: 0 ${padding.md};
   box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
   background-color: ${colors.semantic.background.white};
-  border-radius: ${border.radius.sm};
+  border-radius: 0 0 ${border.radius.sm} ${border.radius.sm};
   overflow: hidden;
   font-size: 14px;
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간략히 적어주세요]**

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

- 모바일 페이지 페이지 padding 값을 레이아웃에서 기본 제공하게 됨 -> 불필요한 padding 제거
- 모바일 검색 input 입력 시 나타나는 검색 내역 드롭다운 UI 틀어진 위치 수정

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.

- 검색결과에서 사용되는 ExplorePlayListCard 컴포넌트 css 수정
- 검색 내역 드롭다운 UI SearchHistory 컴포넌트 css 수정

## 📸 스크린샷 (선택 사항)

- before

  ![image](https://github.com/user-attachments/assets/17ea023a-b048-471f-b67d-ef0c6a76b90d)

- after
  
  ![image](https://github.com/user-attachments/assets/7c06608a-d15f-4634-9b87-0dcd6b366870)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
