### PR TITLE
[🔨 Fix] 플레이리스트 및 프로필 동적 라우팅 수정

### DIFF
--- a/src/constant/url.ts
+++ b/src/constant/url.ts
@@ -12,21 +12,12 @@ const URL: Url = {
   SIGNIN: { text: '로그인', link: '/signin' },
   SEARCH: { text: '검색', link: '/search' },
   FOLLOWPLI: { text: '팔로우', link: '/followpli' },
-  PROFILE: { text: '프로필', link: '/profile' },
+  PROFILE: { text: '프로필', link: '/profile/:userSn' },
   INTERESTS: { text: '관심사 선택', link: '/interests' },
   USERINFO: { text: '내 정보 수정', link: '/userinfo' },
-  VIEWPLI: {
-    text: '플레이리스트 상세',
-    link: '/playlists/view/:pliId',
-  },
-  INSERTPLI: {
-    text: '플레이리스트 생성',
-    link: '/playlists/insert',
-  },
-  UPDATEPLI: {
-    text: '플레이리스트 수정',
-    link: '/playlists/update/:pliId',
-  },
+  VIEWPLI: { text: '플레이리스트 상세', link: '/playlists/view' },
+  INSERTPLI: { text: '플레이리스트 생성', link: '/playlists/insert' },
+  UPDATEPLI: { text: '플레이리스트 수정', link: '/playlists/update' },
 } as const;
 
 export { URL };

--- a/src/routes/routeConfig.tsx
+++ b/src/routes/routeConfig.tsx
@@ -27,6 +27,7 @@ export const routeConfig = [
       { path: URL.HOME.link, element: <HomePage /> },
       { path: URL.SEARCH.link, element: <SearchPage /> },
       { path: URL.VIEWPLI.link, element: <PlaylistViewPage /> },
+      { path: URL.PROFILE.link, element: <ProfilePage /> },
       {
         element: <AuthRoute mode="authenticated" />,
         children: [
@@ -34,7 +35,6 @@ export const routeConfig = [
           { path: URL.FOLLOWPLI.link, element: <FollowPlaylistPage /> },
           { path: URL.INSERTPLI.link, element: <UpsertPlaylistPage /> },
           { path: URL.UPDATEPLI.link, element: <UpsertPlaylistPage /> },
-          { path: URL.PROFILE.link, element: <ProfilePage /> },
           { path: URL.INTERESTS.link, element: <InterestPage /> },
           { path: URL.USERINFO.link, element: <UserInfoPage /> },
         ],


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간략히 적어주세요]**

## 📋 작업 내용

플레이리스트 상세/수정 페이지와 프로필페이지의 url 및 라우팅 정보 수정

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.

- [x] URL 상수 수정
- [x] router 수정


## 📄 기타

프로필 페이지의 링크와 로그인 제한을 수정했습니다.
근데 로그인하지 않았을 때, 네비게이션에서 프로필은 나오지 않도록 추가적인 처리가 필요할 것 같습니다.
