### PR TITLE
[FIX] 프로필 페이지 라우팅과 link 정보를 사용자 시리얼 번호로 입력받도록 수정합니다.

### DIFF
--- a/src/components/InfiniteScroll/InfiniteScroll.tsx
+++ b/src/components/InfiniteScroll/InfiniteScroll.tsx
@@ -3,20 +3,16 @@ import { InfiniteData, UseInfiniteQueryResult } from '@tanstack/react-query';
 import { LoaderWrapper } from '../core';
 
 interface InfiniteScrollProps<T> {
-  useInfiniteQuery: (
-    keyword: string,
-  ) => UseInfiniteQueryResult<InfiniteData<T[]>, Error>;
-  keyword: string;
+  useInfiniteQuery: () => UseInfiniteQueryResult<InfiniteData<T[]>, Error>;
   children: (item: T) => React.ReactNode;
 }
 
 function InfiniteScroll<T>({
   useInfiniteQuery,
-  keyword,
   children,
 }: InfiniteScrollProps<T>) {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } =
-    useInfiniteQuery(keyword);
+    useInfiniteQuery();
 
   const observerRef = useRef<IntersectionObserver | null>(null);
   const lastItemRef = useCallback(

--- a/src/components/card/ProfileCard/ProfileCard.tsx
+++ b/src/components/card/ProfileCard/ProfileCard.tsx
@@ -1,37 +1,31 @@
-import { useUser } from '@/store';
 import * as S from './ProfileCard.styles';
-import { useQuery } from '@tanstack/react-query';
 import defaultImage from '@/assets/avatar.svg';
-import { getUser } from '@/api';
+import { IUserAPISchema } from '@/types';
+
+interface IProfileCard {
+  profile: IUserAPISchema;
+}
 
 /**
  * 프로필 페이지의 사용자 정보 렌더링을 위한 카드 컴포넌트
  * @returns
  */
-const ProfileCard = () => {
-  const user = useUser();
-
-  const { data } = useQuery({
-    queryKey: ['getUser'],
-    queryFn: () => getUser(user?.userSn || ''),
-    enabled: !!user?.userSn,
-  });
-
+const ProfileCard = ({ profile }: IProfileCard) => {
   return (
     <S.CardContainer>
-      <S.CardImage imgUrl={user?.imgUrl || defaultImage} size="10rem" />
-      <S.CardTitle>{data?.name}</S.CardTitle>
+      <S.CardImage imgUrl={profile.imgUrl || defaultImage} size="10rem" />
+      <S.CardTitle>{profile.name}</S.CardTitle>
       <S.CardInfoBox>
         <S.CardStack>
-          <S.B>{data?.myPlaylists.length}</S.B>
+          <S.B>{profile.myPlaylists.length}</S.B>
           <span>플리</span>
         </S.CardStack>
         <S.CardStack>
-          <S.B>{data?.likes.length}</S.B>
+          <S.B>{profile.likes.length}</S.B>
           <span>좋아요</span>
         </S.CardStack>
       </S.CardInfoBox>
-      <p>{data?.description}</p>
+      <p>{profile.description}</p>
     </S.CardContainer>
   );
 };

--- a/src/components/card/UserCard/UserCard.styles.ts
+++ b/src/components/card/UserCard/UserCard.styles.ts
@@ -28,7 +28,8 @@ export const CardTitle = styled.h3`
 `;
 
 export const CardInfoBox = styled.div`
-  width: 100%;
+  width: 50%;
+  margin: auto;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/components/card/UserCard/UserCard.tsx
+++ b/src/components/card/UserCard/UserCard.tsx
@@ -10,7 +10,7 @@ interface IUserProps {
  * @returns
  */
 const UserCard = ({ data }: IUserProps) => {
-  const { imgUrl, name, myPlaylists, followers, followings, userSn } = data;
+  const { imgUrl, name, myPlaylists, userSn, likes } = data;
   return (
     <S.CardContainer to={`/profile/${userSn}`}>
       <S.CardImage src={imgUrl || 'src/assets/avatar.svg'} />
@@ -19,15 +19,11 @@ const UserCard = ({ data }: IUserProps) => {
         <S.CardInfoBox>
           <S.CardStack>
             <S.B>{myPlaylists.length}</S.B>
-            <span>플리</span>
+            <span>플레이리스트</span>
           </S.CardStack>
           <S.CardStack>
-            <S.B>{followers.length}</S.B>
-            <span>팔로워</span>
-          </S.CardStack>
-          <S.CardStack>
-            <S.B>{followings.length}</S.B>
-            <span>팔로잉</span>
+            <S.B>{likes.length}</S.B>
+            <span>좋아요</span>
           </S.CardStack>
         </S.CardInfoBox>
       </S.CardWrapper>

--- a/src/components/layout/desktop/sidebar/MainNavItems/MainNavItems.tsx
+++ b/src/components/layout/desktop/sidebar/MainNavItems/MainNavItems.tsx
@@ -2,8 +2,10 @@ import { useRef } from 'react';
 import { useVisibilityToggle } from '@/hooks';
 import { DESKTOP_NAV_ITEMS, NAV_ICON_SIZE, URL } from '@/constant';
 import { DesktopSearch, NavMenu, SideNavItem } from '@/components';
+import { useUser } from '@/store';
 
 const MainNavItems = () => {
+  const user = useUser();
   const dropdownRef = useRef(null);
   const {
     isVisible: isVisibleSearchForm,
@@ -25,7 +27,12 @@ const MainNavItems = () => {
                     'aria-expanded': isVisibleSearchForm,
                     'aria-controls': 'searchForm',
                   }
-                : { link: navItem.link })}
+                : {
+                    link:
+                      navItem.link === '/profile/:userSn'
+                        ? `/profile/${user?.userSn}`
+                        : navItem.link,
+                  })}
             >
               <NavMenu
                 iconName={navItem.iconName}

--- a/src/components/layout/mobile/MobileNavBar/MobileNavBar.tsx
+++ b/src/components/layout/mobile/MobileNavBar/MobileNavBar.tsx
@@ -2,8 +2,11 @@ import { NavLink } from 'react-router-dom';
 import { MOBILE_NAV_ITEMS } from '@/constant';
 import { NavMenu } from '@/components';
 import * as S from './MobileNavBar.styles';
+import { useUser } from '@/store';
 
 const MobileNavBar = () => {
+  const user = useUser();
+
   return (
     <S.MobileNavBar>
       <S.Navigation>
@@ -13,7 +16,11 @@ const MobileNavBar = () => {
               <NavLink to={navItem.link} aria-label={navItem.text}>
                 <NavMenu
                   iconName={navItem.iconName}
-                  link={navItem.link}
+                  link={
+                    navItem.link === '/profile/:userSn'
+                      ? `/profile/${user?.userSn}`
+                      : navItem.link
+                  }
                   size="2.8rem"
                 />
               </NavLink>

--- a/src/components/layout/mobile/MobileSearch/MobileSearch.styles.ts
+++ b/src/components/layout/mobile/MobileSearch/MobileSearch.styles.ts
@@ -1,6 +1,10 @@
 import styled from 'styled-components';
 import { colors, padding, height, border } from '@/styles';
 
+export const MobileSearchBox = styled.div`
+  position: relative;
+  width: 100%;
+`;
 export const MobileSearch = styled.article`
   z-index: 1;
   position: absolute;

--- a/src/components/layout/mobile/MobileSearch/MobileSearch.tsx
+++ b/src/components/layout/mobile/MobileSearch/MobileSearch.tsx
@@ -13,7 +13,7 @@ const MobileSearch = () => {
   const history = useSearchHistory();
 
   return (
-    <>
+    <S.MobileSearchBox>
       <SearchForm onClick={showVisibility} resetVisibility={resetVisibility} />
 
       {isVisible &&
@@ -29,7 +29,7 @@ const MobileSearch = () => {
           </S.MobileSearch>,
           document.querySelector('#mobileHedaer') as Element,
         )}
-    </>
+    </S.MobileSearchBox>
   );
 };
 

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -1,24 +1,32 @@
 import { ExplorePlayListCard, ProfileCard } from '@/components/card';
 import * as S from './ProfilePage.styles';
-import { useQuery } from '@tanstack/react-query';
-import { bookmarkPlaylist, userPlaylist } from '@/api';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { bookmarkPlaylist, getUser, userPlaylist } from '@/api';
 import { useUser } from '@/store';
 import { LoaderWrapper } from '@/components';
 import { Tab } from '@/components/core/Tab';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 
 const ProfilePage = () => {
   const user = useUser();
   const [tab, setTab] = useState('myPlaylist');
+  const { userSn } = useParams();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    queryClient.resetQueries({ queryKey: ['bookmarkPlaylist', userSn] });
+    queryClient.resetQueries({ queryKey: ['userPlaylist', userSn] });
+    queryClient.resetQueries({ queryKey: ['getUser', userSn] });
+  }, [queryClient, userSn]);
 
   const {
     data: myPlaylists,
     isSuccess: mySuccess,
     isLoading: myLoading,
   } = useQuery({
-    queryKey: ['userPlaylist'],
-    queryFn: () => userPlaylist(user?.userSn),
-    enabled: !!user?.userSn,
+    queryKey: ['userPlaylist', userSn],
+    queryFn: () => userPlaylist(userSn),
     refetchOnWindowFocus: false,
   });
 
@@ -27,38 +35,42 @@ const ProfilePage = () => {
     isSuccess: bookmarkSuccess,
     isLoading: bookmarkLoading,
   } = useQuery({
-    queryKey: ['bookmarkPlaylist'],
-    queryFn: () => bookmarkPlaylist(user?.userSn),
-    enabled: !!user?.userSn,
+    queryKey: ['bookmarkPlaylist', userSn],
+    queryFn: () => bookmarkPlaylist(userSn),
     refetchOnWindowFocus: false,
   });
 
+  const { data: profile, isLoading } = useQuery({
+    queryKey: ['getUser', userSn],
+    queryFn: () => getUser(userSn || ''),
+  });
+
+  if (isLoading && myLoading && bookmarkLoading)
+    return <LoaderWrapper isLoading={true} />;
+  if (!profile) return <div>잘못된 접근입니다.</div>;
+
   return (
     <S.ProfileContainer>
-      <ProfileCard />
-      <Tab
-        items={[
-          { label: 'myPlaylist', title: '플레이리스트' },
-          { label: 'bookmarks', title: '구독 플레이리스트' },
-        ]}
-        selected={tab}
-        setSelected={setTab}
-      />
-      {tab === 'myPlaylist' ? (
-        <LoaderWrapper isLoading={myLoading}>
-          {mySuccess &&
-            myPlaylists.map((playlist, i) => (
-              <ExplorePlayListCard key={i} data={playlist} />
-            ))}
-        </LoaderWrapper>
-      ) : (
-        <LoaderWrapper isLoading={bookmarkLoading}>
-          {bookmarkSuccess &&
-            bookmarks.map((playlist, i) => (
-              <ExplorePlayListCard key={i} data={playlist} />
-            ))}
-        </LoaderWrapper>
+      <ProfileCard profile={profile} />
+      {user?.userSn === userSn && (
+        <Tab
+          items={[
+            { label: 'myPlaylist', title: '플레이리스트' },
+            { label: 'bookmarks', title: '구독 플레이리스트' },
+          ]}
+          selected={tab}
+          setSelected={setTab}
+        />
       )}
+      {tab === 'myPlaylist'
+        ? mySuccess &&
+          myPlaylists.map((playlist, i) => (
+            <ExplorePlayListCard key={i} data={playlist} />
+          ))
+        : bookmarkSuccess &&
+          bookmarks.map((playlist, i) => (
+            <ExplorePlayListCard key={i} data={playlist} />
+          ))}
     </S.ProfileContainer>
   );
 };

--- a/src/pages/SearchPage/SearchPage.tsx
+++ b/src/pages/SearchPage/SearchPage.tsx
@@ -6,17 +6,19 @@ import { useSearchPlaylist, useSearchUser } from '@/hooks';
 import { Fragment } from 'react/jsx-runtime';
 
 const SearchPage = () => {
-  const [searchParam, setSearchParam] = useSearchParams();
+  const [searchParam] = useSearchParams();
   const keyword = searchParam.get('keyword') || '';
-  const display = searchParam.get('display') || '';
-  const { data, hasNextPage } = useSearchUser(keyword, 2);
+  const { data, hasNextPage, fetchNextPage } = useSearchUser(keyword, 2);
 
   const handleMoreUser = () => {
-    searchParam.set('display', 'user');
-    setSearchParam(searchParam);
+    return fetchNextPage();
   };
 
   if (!keyword) return <div>적절하지 않은 접근입니다.</div>;
+
+  const useHandlePlaylist = () => {
+    return useSearchPlaylist(keyword);
+  };
 
   return (
     <S.SearchContainer>
@@ -31,23 +33,16 @@ const SearchPage = () => {
 
       {data?.pages[0].length === 0 && <div>검색결과가 존재하지 않습니다.</div>}
 
-      {hasNextPage && (
+      {data?.pages[0].length !== 0 && hasNextPage && (
         <Button $bgColor="white" $width="100%" onClick={handleMoreUser}>
           더보기
         </Button>
       )}
 
-      {!display && (
-        <>
-          <S.SearchTitle>플레이리스트</S.SearchTitle>
-          <InfiniteScroll
-            keyword={keyword}
-            useInfiniteQuery={useSearchPlaylist}
-          >
-            {(data) => <ExplorePlayListCard data={data} />}
-          </InfiniteScroll>
-        </>
-      )}
+      <S.SearchTitle>플레이리스트</S.SearchTitle>
+      <InfiniteScroll useInfiniteQuery={useHandlePlaylist}>
+        {(data) => <ExplorePlayListCard data={data} />}
+      </InfiniteScroll>
     </S.SearchContainer>
   );
 };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**프로필 페이지 라우팅과 link 정보를 사용자 시리얼 번호로 입력받도록 수정합니다. #50 **

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

- 사용자의 시리얼 넘버와 특정 사용자의 시리얼 넘버를 비교하여 유효성 검사를 진행합니다.
- 사용자의 시리얼 넘버 혹은 올바르지 않은 정보일 경우 에러를 처리합니다.
- 프로필과 플레이리스트, 구독 플레이리스트에 대한 데이터 패칭을 구현합니다.

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.

- 네비게이션바에서 프로필로 이동할 경우, 사용자의 시리얼 넘버를 적용하도록 수정합니다.
- 무한스크롤의 올바르지 않은 props 값을 전달하던 방식을 수정합니다.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
