### PR TITLE
[🔨 Fix] 자동생성되는 재생목록 썸네일 이미지에 맞춰서 보이도록 css 수정

### DIFF
--- a/src/components/feeds/InteractionBar/InteractionBar.styles.ts
+++ b/src/components/feeds/InteractionBar/InteractionBar.styles.ts
@@ -5,7 +5,7 @@ export const InteractionBar = styled.article`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  height: '4rem';
+  height: 4rem;
   gap: ${padding.sm};
 
   .position-right {

--- a/src/components/feeds/Thumbnails/Thumbnails.styles.ts
+++ b/src/components/feeds/Thumbnails/Thumbnails.styles.ts
@@ -59,7 +59,10 @@ export const Thumbnails = styled(Link)`
 export const Thumbnail = styled.picture`
   img {
     display: block;
-    height: 100%;
     margin: 0 auto;
+    width: 100%;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%) scale(1.01);
   }
 `;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간략히 적어주세요]**

## 📋 작업 내용

- 플레이리스트 생성 시 자동 생성되는 썸네일 이미지를 기준으로 공백 없이 보이도록 썸네일 CSS 수정

자동생성 되는 썸네일 이미지는 위 아래 검은 공백이 존재

![image](https://github.com/user-attachments/assets/31f58e0d-a16a-4ab6-94ef-7f9cedabfacd)


## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.

- [x] 썸네일 이미지가 위아래 공백 관계없이 썸네일 사진이 꽉차도록 CSS 수정

## 📸 스크린샷 (선택 사항)

- 수정 전

  ![image](https://github.com/user-attachments/assets/0764f200-360b-4556-a2d4-4ff06ffd6952)


- 수정 후

  ![image](https://github.com/user-attachments/assets/1cf2f5dc-8173-4949-9e25-e5e80e71370a)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
