### PR TITLE
[🔨 Fix] 로그인 전 프로필 메뉴 라우팅 제어 및 프로필 페이지 라우트 관련 이슈 해결

### DIFF
--- a/src/components/feeds/Feed/Feed.tsx
+++ b/src/components/feeds/Feed/Feed.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { RiMoreFill } from 'react-icons/ri';
-import { URL, QUERY_PARAMS } from '@/constant';
+import { URL, QUERY_PARAMS, PATH_PARAMS } from '@/constant';
 import { useFetchAuthor, useContextFeed } from '@/hooks';
 import { ProfileImage, TagList } from '@/components';
 import { Thumbnails, InteractionBar } from '@/components/feeds';
@@ -30,7 +30,10 @@ const Feed = ({ playlistSn }: { playlistSn: string }) => {
     indexView: link + `&${QUERY_PARAMS.PLAYLIST_INDEX}=true`,
     commentView: link + `&${QUERY_PARAMS.PLAYLIST_COMMENTS}=true`,
   };
-  const authorProfileLink = URL.PROFILE.link.replace(':userSn', userSn);
+  const authorProfileLink = URL.PROFILE.link.replace(
+    PATH_PARAMS.USER_SN,
+    userSn,
+  );
 
   return (
     <S.Feed>

--- a/src/components/layout/common/NavMenu/NavMenu.tsx
+++ b/src/components/layout/common/NavMenu/NavMenu.tsx
@@ -21,10 +21,10 @@ type MenuProps = {
   iconName: string;
   text?: string;
   size: string;
-  link?: string;
+  linkForActive?: string;
 };
 
-const NavMenu = ({ iconName, text, size, link }: MenuProps) => {
+const NavMenu = ({ iconName, text, size, linkForActive }: MenuProps) => {
   const { pathname } = useLocation();
 
   const navIcons = new Map([
@@ -89,7 +89,7 @@ const NavMenu = ({ iconName, text, size, link }: MenuProps) => {
 
   return (
     <S.NavMenu>
-      {pathname === link ? iconInfo?.activeIcon : iconInfo?.icon}
+      {pathname === linkForActive ? iconInfo?.activeIcon : iconInfo?.icon}
       {text ? <span>{text}</span> : ''}
     </S.NavMenu>
   );

--- a/src/components/layout/desktop/sidebar/MainNavItems/MainNavItems.tsx
+++ b/src/components/layout/desktop/sidebar/MainNavItems/MainNavItems.tsx
@@ -36,7 +36,7 @@ const MainNavItems = () => {
                 iconName={navItem.iconName}
                 text={navItem.text}
                 size={NAV_ICON_SIZE}
-                link={navItem.link}
+                linkForActive={generateRoutingLink(navItem.link, userSn)}
               />
             </SideNavItem>
           </li>

--- a/src/components/layout/desktop/sidebar/MainNavItems/MainNavItems.tsx
+++ b/src/components/layout/desktop/sidebar/MainNavItems/MainNavItems.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { useVisibilityToggle } from '@/hooks';
-import { DESKTOP_NAV_ITEMS, NAV_ICON_SIZE, URL, PATH_PARAMS } from '@/constant';
+import { generateRoutingLink } from '@/utils';
+import { DESKTOP_NAV_ITEMS, NAV_ICON_SIZE, URL } from '@/constant';
 import { DesktopSearch, NavMenu, SideNavItem } from '@/components';
 import { useUserSn } from '@/store';
 
@@ -28,15 +29,7 @@ const MainNavItems = () => {
                     'aria-controls': 'searchForm',
                   }
                 : {
-                    link:
-                      navItem.link === URL.PROFILE.link
-                        ? userSn
-                          ? URL.PROFILE.link.replace(
-                              PATH_PARAMS.USER_SN,
-                              userSn,
-                            )
-                          : URL.SIGNIN.link
-                        : navItem.link,
+                    link: generateRoutingLink(navItem.link, userSn),
                   })}
             >
               <NavMenu

--- a/src/components/layout/desktop/sidebar/MainNavItems/MainNavItems.tsx
+++ b/src/components/layout/desktop/sidebar/MainNavItems/MainNavItems.tsx
@@ -1,11 +1,11 @@
 import { useRef } from 'react';
 import { useVisibilityToggle } from '@/hooks';
-import { DESKTOP_NAV_ITEMS, NAV_ICON_SIZE, URL } from '@/constant';
+import { DESKTOP_NAV_ITEMS, NAV_ICON_SIZE, URL, PATH_PARAMS } from '@/constant';
 import { DesktopSearch, NavMenu, SideNavItem } from '@/components';
-import { useUser } from '@/store';
+import { useUserSn } from '@/store';
 
 const MainNavItems = () => {
-  const user = useUser();
+  const userSn = useUserSn();
   const dropdownRef = useRef(null);
   const {
     isVisible: isVisibleSearchForm,
@@ -29,8 +29,13 @@ const MainNavItems = () => {
                   }
                 : {
                     link:
-                      navItem.link === '/profile/:userSn'
-                        ? `/profile/${user?.userSn}`
+                      navItem.link === URL.PROFILE.link
+                        ? userSn
+                          ? URL.PROFILE.link.replace(
+                              PATH_PARAMS.USER_SN,
+                              userSn,
+                            )
+                          : URL.SIGNIN.link
                         : navItem.link,
                   })}
             >

--- a/src/components/layout/mobile/MobileHeader/MobileHeader.tsx
+++ b/src/components/layout/mobile/MobileHeader/MobileHeader.tsx
@@ -1,18 +1,25 @@
 import { useLocation } from 'react-router-dom';
 import { URL } from '@/constant';
+import { generateRoutingLink } from '@/utils';
+import { useUserSn } from '@/store';
 import { Logo, MobileMoreWrap } from '@/components';
-import * as S from './MobileHeader.styles';
 import { MobileSearch } from '../MobileSearch';
+import * as S from './MobileHeader.styles';
 
 const MobileHeader = () => {
   const { pathname } = useLocation();
+  const userSn = useUserSn();
 
   return (
     <header id="mobileHedaer">
       <S.MobileHeader>
         <Logo width="12rem" />
 
-        {pathname === URL.PROFILE.link ? <MobileMoreWrap /> : <MobileSearch />}
+        {pathname === generateRoutingLink(URL.PROFILE.link, userSn) ? (
+          <MobileMoreWrap />
+        ) : (
+          <MobileSearch />
+        )}
       </S.MobileHeader>
     </header>
   );

--- a/src/components/layout/mobile/MobileNavBar/MobileNavBar.tsx
+++ b/src/components/layout/mobile/MobileNavBar/MobileNavBar.tsx
@@ -20,7 +20,7 @@ const MobileNavBar = () => {
               >
                 <NavMenu
                   iconName={navItem.iconName}
-                  link={navItem.link}
+                  linkForActive={generateRoutingLink(navItem.link, userSn)}
                   size="2.8rem"
                 />
               </NavLink>

--- a/src/components/layout/mobile/MobileNavBar/MobileNavBar.tsx
+++ b/src/components/layout/mobile/MobileNavBar/MobileNavBar.tsx
@@ -1,8 +1,9 @@
 import { NavLink } from 'react-router-dom';
-import { MOBILE_NAV_ITEMS, URL, PATH_PARAMS } from '@/constant';
+import { generateRoutingLink } from '@/utils';
+import { MOBILE_NAV_ITEMS } from '@/constant';
+import { useUserSn } from '@/store';
 import { NavMenu } from '@/components';
 import * as S from './MobileNavBar.styles';
-import { useUserSn } from '@/store';
 
 const MobileNavBar = () => {
   const userSn = useUserSn();
@@ -14,13 +15,7 @@ const MobileNavBar = () => {
           {MOBILE_NAV_ITEMS.map((navItem, index) => (
             <li key={`${index}-${navItem.text}`}>
               <NavLink
-                to={
-                  navItem.link === URL.PROFILE.link
-                    ? userSn
-                      ? URL.PROFILE.link.replace(PATH_PARAMS.USER_SN, userSn)
-                      : URL.SIGNIN.link
-                    : navItem.link
-                }
+                to={generateRoutingLink(navItem.link, userSn)}
                 aria-label={navItem.text}
               >
                 <NavMenu

--- a/src/components/layout/mobile/MobileNavBar/MobileNavBar.tsx
+++ b/src/components/layout/mobile/MobileNavBar/MobileNavBar.tsx
@@ -1,11 +1,11 @@
 import { NavLink } from 'react-router-dom';
-import { MOBILE_NAV_ITEMS } from '@/constant';
+import { MOBILE_NAV_ITEMS, URL, PATH_PARAMS } from '@/constant';
 import { NavMenu } from '@/components';
 import * as S from './MobileNavBar.styles';
-import { useUser } from '@/store';
+import { useUserSn } from '@/store';
 
 const MobileNavBar = () => {
-  const user = useUser();
+  const userSn = useUserSn();
 
   return (
     <S.MobileNavBar>
@@ -13,14 +13,19 @@ const MobileNavBar = () => {
         <ul>
           {MOBILE_NAV_ITEMS.map((navItem, index) => (
             <li key={`${index}-${navItem.text}`}>
-              <NavLink to={navItem.link} aria-label={navItem.text}>
+              <NavLink
+                to={
+                  navItem.link === URL.PROFILE.link
+                    ? userSn
+                      ? URL.PROFILE.link.replace(PATH_PARAMS.USER_SN, userSn)
+                      : URL.SIGNIN.link
+                    : navItem.link
+                }
+                aria-label={navItem.text}
+              >
                 <NavMenu
                   iconName={navItem.iconName}
-                  link={
-                    navItem.link === '/profile/:userSn'
-                      ? `/profile/${user?.userSn}`
-                      : navItem.link
-                  }
+                  link={navItem.link}
                   size="2.8rem"
                 />
               </NavLink>

--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -6,4 +6,3 @@ export * from './interests';
 export * from './reactQuery';
 export * from './playlistLimits';
 export * from './iconSize';
-export * from './queryParams';

--- a/src/constant/queryParams.ts
+++ b/src/constant/queryParams.ts
@@ -1,7 +1,0 @@
-export const QUERY_PARAMS = {
-  PLAYLIST_SN: 'playlistSn',
-  PLAYLIST_INFO: 'playlistInfo',
-  PLAYLIST_INDEX: 'playlistIndex',
-  PLAYLIST_COMMENTS: 'comments',
-  VIDEO_INDEX: 'videoIndex',
-};

--- a/src/constant/url.ts
+++ b/src/constant/url.ts
@@ -33,6 +33,15 @@ export const URL: Url = {
   },
 } as const;
 
+export const REQUIRED_AUTH_URLS = [
+  URL.FOLLOWPLI.link,
+  URL.INSERTPLI.link,
+  URL.USERINFO.link,
+  URL.INTERESTS.link,
+  URL.VIEWPLI.link,
+  URL.UPDATEPLI.link,
+];
+
 export const QUERY_PARAMS = {
   PLAYLIST_SN: 'playlistSn',
   PLAYLIST_INFO: 'playlistInfo',

--- a/src/constant/url.ts
+++ b/src/constant/url.ts
@@ -1,18 +1,22 @@
 /** Routes에서 사용 */
 type Url = Record<string, { text: string; link: string }>;
 
+export const PATH_PARAMS = {
+  USER_SN: ':userSn',
+};
+
 /**
  * 라우팅, 네비게이션에 필요한 url 객체
  * key 값은 복잡성을 줄이기 위해 다른 상수로 만들지 않음
  * @return Url
  */
-const URL: Url = {
+export const URL: Url = {
   INDEX: { text: '', link: '/' },
   HOME: { text: '홈', link: '/home' },
   SIGNIN: { text: '로그인', link: '/signin' },
   SEARCH: { text: '검색', link: '/search' },
   FOLLOWPLI: { text: '팔로우', link: '/followpli' },
-  PROFILE: { text: '프로필', link: '/profile/:userSn' },
+  PROFILE: { text: '프로필', link: `/profile/${PATH_PARAMS.USER_SN}` },
   INTERESTS: { text: '관심사 선택', link: '/interests' },
   USERINFO: { text: '내 정보 수정', link: '/userinfo' },
   VIEWPLI: {
@@ -29,4 +33,10 @@ const URL: Url = {
   },
 } as const;
 
-export { URL };
+export const QUERY_PARAMS = {
+  PLAYLIST_SN: 'playlistSn',
+  PLAYLIST_INFO: 'playlistInfo',
+  PLAYLIST_INDEX: 'playlistIndex',
+  PLAYLIST_COMMENTS: 'comments',
+  VIDEO_INDEX: 'videoIndex',
+};

--- a/src/utils/navigate.ts
+++ b/src/utils/navigate.ts
@@ -1,6 +1,28 @@
-import { URL } from '@/constant';
+import { URL, REQUIRED_AUTH_URLS, PATH_PARAMS } from '@/constant';
 
 /** Path, Route, Navagate에 관련된 유틸함수 */
+
+/**
+ * generateRoutingLink - path 문자열과 userSn 문자열을 인자로 넘기고 로그인이 필요한 페이지일 경우 로그인 페이지로 리다이렉트 할 수 있는 링크를 반환 합니다.
+ *
+ * @param {string} path
+ * @param {string} userSn
+ * @returns {string} 리다이렉트할 URL
+ */
+export const generateRoutingLink = (path: string, userSn?: string): string => {
+  if (!userSn) {
+    if (REQUIRED_AUTH_URLS.includes(path)) return URL.SIGNIN.link;
+    if (path === URL.PROFILE.link) return URL.SIGNIN.link;
+
+    return path;
+  }
+
+  if (path === URL.PROFILE.link) {
+    return URL.PROFILE.link.replace(PATH_PARAMS.USER_SN, userSn);
+  }
+
+  return path;
+};
 
 /**
  * getPageTitle - path 문자열을 인자로 넘기고 해당 경로의 페이지 타이틀을 반환 합니다.


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간략히 적어주세요]**

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

- [x] 로그인 전 네비게이션 프로필 메뉴 클릭 시 로그인 페이지 이동
- [x] PC 화면에서 네비게이션 프로필 메뉴 active UI가 적용되지 않는 문제 해결
- [x] 모바일 화면에서 프로필 페이지 더보기 아이콘이 사라진 문제 해결

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.

- 네비게이션에 사용하기 위한 인증 권한이 필요한 URL의 경우 로그인 페이지로 반환하는 유틸 함수 생성
- 사이드바와 모바일 네브바 중복 코드 제거
- 이슈 해결을 위한 코드 수정


## 📸 스크린샷 (선택 사항)

- before : 아이콘 활성화가 안됨

  ![image](https://github.com/user-attachments/assets/1d8a4c94-7e51-4892-b9d6-6ed780771e4b)

- after

  ![image](https://github.com/user-attachments/assets/f20751f8-3180-4942-95f1-3936bc64e9f0)



- before : 더보기 버튼이 보이지 않음
 
  ![image](https://github.com/user-attachments/assets/612f5ef1-a8ac-4fa2-becd-665b0afc6b2d)


- after

  ![image](https://github.com/user-attachments/assets/fec6b684-de45-4498-8f99-9f56b7e8d4e8)



## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
